### PR TITLE
Device availability checker

### DIFF
--- a/android/src/main/kotlin/dev/artyboy/flutter_sunyard_i80/DeviceMethodCallHandler.kt
+++ b/android/src/main/kotlin/dev/artyboy/flutter_sunyard_i80/DeviceMethodCallHandler.kt
@@ -1,0 +1,21 @@
+package dev.artyboy.flutter_sunyard_i80
+
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+
+class DeviceMethodCallHandler(deviceModule: DeviceModule): MethodCallHandler {
+    private lateinit var deviceModule: DeviceModule;
+
+    init {
+        this.deviceModule = deviceModule
+    }
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when(call.method) {
+            deviceModule.isAvailableString -> {
+                result.success(deviceModule.isAvailable())
+            }
+            else -> result.notImplemented()
+        }
+    }
+}

--- a/android/src/main/kotlin/dev/artyboy/flutter_sunyard_i80/DeviceModule.kt
+++ b/android/src/main/kotlin/dev/artyboy/flutter_sunyard_i80/DeviceModule.kt
@@ -1,0 +1,12 @@
+package dev.artyboy.flutter_sunyard_i80
+
+/** A module for device status */
+class DeviceModule {
+    /** Method string of [isAvailable] */
+    val isAvailableString: String = "isAvailable";
+
+    /** Check if this device is the Sunyard i80 or not */
+    fun isAvailable(): Boolean {
+        return System.getProperty("http.agent").contains("i80");
+    }
+}

--- a/android/src/main/kotlin/dev/artyboy/flutter_sunyard_i80/FlutterSunyardI80Plugin.kt
+++ b/android/src/main/kotlin/dev/artyboy/flutter_sunyard_i80/FlutterSunyardI80Plugin.kt
@@ -12,13 +12,23 @@ class FlutterSunyardI80Plugin: FlutterPlugin {
 
   private var terminalInfoChannel: MethodChannel? = null
 
+  /** Method channel for [DeviceModule] */
+  private var deviceChannel: MethodChannel? = null
+
   /** Method channel string of [printerChannel] */
   private val printerChannelName: String = "printer"
 
   private val terminalInfoChannelName: String = "terminal_info"
 
+  /** Method channel string of [deviceChannel] */
+  private val deviceChannelName: String = "device"
+
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    val isDeviceAvailable = System.getProperty("http.agent").contains("i80")
+    val deviceModule = DeviceModule()
+    deviceChannel = MethodChannel(flutterPluginBinding.binaryMessenger, deviceChannelName)
+    deviceChannel?.setMethodCallHandler(DeviceMethodCallHandler(deviceModule))
+
+    val isDeviceAvailable = deviceModule.isAvailable()
     if (isDeviceAvailable) {
       DeviceMaster.getInstance().init(flutterPluginBinding.applicationContext)
 

--- a/android/src/main/kotlin/dev/artyboy/flutter_sunyard_i80/FlutterSunyardI80Plugin.kt
+++ b/android/src/main/kotlin/dev/artyboy/flutter_sunyard_i80/FlutterSunyardI80Plugin.kt
@@ -10,6 +10,7 @@ class FlutterSunyardI80Plugin: FlutterPlugin {
   /** Method channel for [PrinterModule] */
   private var printerChannel: MethodChannel? = null
 
+  /** Method channel for [TerminalInfoModule] */
   private var terminalInfoChannel: MethodChannel? = null
 
   /** Method channel for [DeviceModule] */
@@ -18,6 +19,7 @@ class FlutterSunyardI80Plugin: FlutterPlugin {
   /** Method channel string of [printerChannel] */
   private val printerChannelName: String = "printer"
 
+  /** Method channel string of [terminalInfoChannel] */
   private val terminalInfoChannelName: String = "terminal_info"
 
   /** Method channel string of [deviceChannel] */

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,6 +17,8 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   bool isPrinterAvailable = false;
 
+  bool isDeviceAvailable = false;
+
   String serialNumber = "";
 
   @override
@@ -26,11 +28,17 @@ class _MyAppState extends State<MyApp> {
   }
 
   void initPage() async {
-    final isTrue = await Printer.isPrinterAvailable();
+    final isDeviceAvailable = await Device.isAvailable();
+    final isPrinterAvailable = await Printer.isPrinterAvailable();
     serialNumber = await TerminalInfo.serialNumber;
-    if (isTrue) {
+    if (isDeviceAvailable) {
       setState(() {
-        isPrinterAvailable = isTrue;
+        this.isDeviceAvailable = isDeviceAvailable;
+      });
+    }
+    if (isPrinterAvailable) {
+      setState(() {
+        this.isPrinterAvailable = isPrinterAvailable;
       });
     }
   }
@@ -47,6 +55,9 @@ class _MyAppState extends State<MyApp> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
+              Center(
+                child: Text('Device status: ${deviceStatus()}'),
+              ),
               Center(
                 child: Text('Printer Serial Number: $serialNumber'),
               ),
@@ -98,6 +109,10 @@ class _MyAppState extends State<MyApp> {
         ),
       ),
     );
+  }
+
+  String deviceStatus() {
+    return isDeviceAvailable ? "Available" : "Unavailable";
   }
 
   String printerStatus() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,7 +59,7 @@ class _MyAppState extends State<MyApp> {
                 child: Text('Device status: ${deviceStatus()}'),
               ),
               Center(
-                child: Text('Printer Serial Number: $serialNumber'),
+                child: Text('Device Serial Number: $serialNumber'),
               ),
               Center(
                 child: Text('Printer status: ${printerStatus()}'),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -76,7 +76,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "1.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/lib/flutter_sunyard_i80.dart
+++ b/lib/flutter_sunyard_i80.dart
@@ -1,6 +1,7 @@
 /// A Flutter library that help you utilize functionalities on the Sunyard i80 terminal.
 library;
 
+export 'src/device.dart';
 export 'src/printer_align.dart';
 export 'src/printer_paper_feed.dart';
 export 'src/printer_font_size.dart';

--- a/lib/src/device.dart
+++ b/lib/src/device.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/services.dart';
+
+/// A class for device status
+class Device {
+  static const MethodChannel _methodChannel = MethodChannel(_methodChannelName);
+  
+  static const String _methodChannelName = "device";
+  
+  static const String _isAvailableMethodString = "isAvailable";
+
+  /// Whether the device is Sunyard i80 or not
+  static Future<bool> isAvailable() async {
+    try {
+      final result = await _methodChannel.invokeMethod(_isAvailableMethodString);
+
+      return result;
+    } catch (e) {
+      return false;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_sunyard_i80
 description: A Flutter plugin that helps you utilize functionalities on Sunyard i80 EDC POS terminal
-version: 0.0.1
+version: 1.0.0
 homepage: https://github.com/philaphonh/flutter_sunyard_i80
 
 environment:


### PR DESCRIPTION
- Add a device availability checker class separately from a printer status checker. This will help developers check whether the device is a Sunyard i80 or not.
- Set plugin version to 1.0.0
- Minor updates